### PR TITLE
Parse the Ollama response as a ResponseBody object

### DIFF
--- a/lib/llm/ollama_client.dart
+++ b/lib/llm/ollama_client.dart
@@ -90,7 +90,14 @@ $conversationText""",
         data: bodyStr,
       );
 
-      var jsonData = response.data;
+      var jsonData;
+      if (response.data is ResponseBody) {
+        final responseBody = response.data as ResponseBody;
+        final responseStr = await utf8.decodeStream(responseBody.stream);
+        jsonData = jsonDecode(responseStr);
+      } else {
+        jsonData = response.data;
+      }
       Logger.root.fine('Response data: ${jsonEncode(jsonData)}');
       final message = jsonData['message'];
 

--- a/lib/llm/ollama_client.dart
+++ b/lib/llm/ollama_client.dart
@@ -86,7 +86,7 @@ $conversationText""",
 
     try {
       final response = await _dio.post(
-        "$baseUrl/api/chat",
+        "$baseUrl/v1/chat/completions",
         data: bodyStr,
       );
 
@@ -99,7 +99,7 @@ $conversationText""",
         jsonData = response.data;
       }
       Logger.root.fine('Response data: ${jsonEncode(jsonData)}');
-      final message = jsonData['message'];
+      final message = jsonData['choices'][0]['message'];
 
       // 解析工具调用
       final toolCalls = message['tool_calls']
@@ -118,7 +118,7 @@ $conversationText""",
         toolCalls: toolCalls,
       );
     } catch (e) {
-      throw await handleError(e, 'Ollama', '$baseUrl/api/chat', bodyStr);
+      throw await handleError(e, 'Ollama', '$baseUrl/v1/chat/completions', bodyStr);
     }
   }
 
@@ -146,7 +146,7 @@ $conversationText""",
     try {
       _dio.options.responseType = ResponseType.stream;
       final response = await _dio.post(
-        "$baseUrl/api/chat",
+        "$baseUrl/v1/chat/completions",
         data: jsonEncode(body),
       );
 
@@ -166,11 +166,17 @@ $conversationText""",
 
             try {
               final json = jsonDecode(jsonStr);
-              final message = json['message'];
-              if (message == null) continue;
+
+              // 检查 choices 数组是否为空
+              if (json['choices'] == null || json['choices'].isEmpty) {
+                continue;
+              }
+
+              final delta = json['choices'][0]['delta'];
+              if (delta == null) continue;
 
               // 解析工具调用
-              final toolCalls = message['tool_calls']
+              final toolCalls = delta['tool_calls']
                   ?.map<ToolCall>((t) => ToolCall(
                         id: t['id'] ?? '',
                         type: 'function',
@@ -182,11 +188,10 @@ $conversationText""",
                       ))
                   ?.toList();
 
-              // 只有当 content 不为空或有工具调用时才yield
-              final content = message['content'];
-              if (content?.isNotEmpty == true || toolCalls != null) {
+              // 只在有内容或工具调用时才yield响应
+              if (delta['content'] != null || toolCalls != null) {
                 yield LLMResponse(
-                  content: content ?? '',
+                  content: delta['content'],
                   toolCalls: toolCalls,
                 );
               }
@@ -199,7 +204,7 @@ $conversationText""",
       }
     } catch (e) {
       throw await handleError(
-          e, 'Ollama', '$baseUrl/api/chat', jsonEncode(body));
+          e, 'Ollama', "$baseUrl/v1/chat/completions", jsonEncode(body));
     }
   }
 }


### PR DESCRIPTION
This PR provides:

* Ollama endpoint rename from `/api/chat` to `/v1/chat/completions`
* Fix response handling code to properly parse incoming stream chunks from Ollama
Fixes

I guess this PR fixes a few problems mentioned in https://github.com/daodao97/chatmcp/issues/52